### PR TITLE
fixes of store and store_io

### DIFF
--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -85,11 +85,11 @@ impl MetaPage {
     }
 
     fn expected_file_len(&self) -> u64 {
-        (1 + self.num_meta_byte_pages() as u64 + self.num_pages) * PAGE_SIZE
+        (1 + self.num_meta_byte_pages() as u64 + self.num_pages) * PAGE_SIZE as u64
     }
 
     fn num_meta_byte_pages(&self) -> usize {
-        ((self.num_pages + 4095) / PAGE_SIZE) as usize
+        ((self.num_pages + 4095) / PAGE_SIZE as u64) as usize
     }
 
     fn from_page(page: &[u8]) -> Self {


### PR DESCRIPTION
+ compilation fixes
+ use `store.data_page_offset` as base offset to write and read page_ids into/from file
+ completion_event.result() returns the return value of the syscall and for now both read and write indicate an error with -1