### PR TITLE
fix io remove the sqpoll flag

### DIFF
--- a/src/store/io.rs
+++ b/src/store/io.rs
@@ -70,8 +70,6 @@ fn run_worker(
 
     let mut ring = IoUring::<squeue::Entry, cqueue::Entry>::builder()
         .setup_single_issuer()
-        .setup_sqpoll(100)
-        // .setup_iopoll
         .build(RING_CAPACITY)
         .expect("Error building io_uring");
 


### PR DESCRIPTION
The iouring configuration builder parameter [sqpoll] takes a parameter of the number of milliseconds after which the spawned kernel thread will go sleeping in case no submissions happened during that period.

This API has some quirks. Notably, it requires you to call io_uring_enter with the flag `IORING_ENTER_SQ_WAKEUP`. To check whether the SQ thread is required to wake up you need to check the flags set by the kernel for `IORING_SQ_NEED_WAKEUP`. `submit` call does this, but we would have to do it ourselves when we call io_uring_enter directly.

All of this seems to be premature so this commit just removes this flag.

[sqpoll]: https://docs.rs/io-uring/0.6.4/io_uring/struct.Builder.html#method.setup_sqpoll