### PR TITLE
LeafStore sync integration

### DIFF
--- a/src/beatree/leaf/store.rs
+++ b/src/beatree/leaf/store.rs
@@ -15,6 +15,9 @@ pub struct LeafStoreReader {
     io_receiver: Receiver<CompleteIo>,
 }
 
+/// The LeafStoreWriter enables dynamic allocation and release of Leaf Pages.
+/// Upon calling commit, it returns a list of encoded pages that must be written
+/// to storage to reflect the LeafStore's state at that moment
 pub struct LeafStoreWriter {
     store_file: File,
     io_handle_index: usize,
@@ -22,11 +25,15 @@ pub struct LeafStoreWriter {
     io_receiver: Receiver<CompleteIo>,
     // Monotonic page number, used when the free list is empty
     bump: PageNumber,
-    // This is the max supported page number + 1.
-    // + 1 to easily handle the case where the file is empty and each page,
-    // starting from page_number 0, will exceed
-    max_bump: PageNumber,
+    // The leaf store is an array of pages, with indices as PageNumbers,
+    // file_max_bump can be considered as either the size of the array
+    // or a page number one greater than the maximum bump value that can be used to
+    // safely write a page to storage without necessitating a file growth operation
+    file_max_bump: PageNumber,
     free_list: FreeList,
+    // Used for storing transitional data between commits
+    released: Vec<PageNumber>,
+    pending: Vec<(PageNumber, LeafNode)>,
 }
 
 /// creates a pair of LeafStoreReader and LeafStoreWriter over a possibly already existing File.
@@ -62,7 +69,9 @@ pub fn create(
         io_sender: wr_io_sender,
         io_receiver: wr_io_receiver,
         bump,
-        max_bump: PageNumber((file_size / PAGE_SIZE) as u32),
+        file_max_bump: PageNumber((file_size / PAGE_SIZE) as u32),
+        pending: vec![],
+        released: vec![],
     };
 
     let reader = LeafStoreReader {
@@ -109,37 +118,6 @@ impl LeafStoreReader {
 }
 
 impl LeafStoreWriter {
-    // create a LeafStoreTx able to append and release leaves from the LeafStore
-    pub fn start_tx<'a>(&'a mut self) -> LeafStoreTx<'a> {
-        LeafStoreTx {
-            bump: self.bump,
-            free_list: &mut self.free_list,
-            max_bump: self.max_bump,
-            to_allocate: vec![],
-            released: vec![],
-            exceeded: vec![],
-        }
-    }
-}
-
-pub struct LeafStoreTx<'a> {
-    bump: PageNumber,
-    free_list: &'a mut FreeList,
-    max_bump: PageNumber,
-    released: Vec<PageNumber>,
-    to_allocate: Vec<(PageNumber, LeafNode)>,
-    exceeded: Vec<(PageNumber, LeafNode)>,
-}
-
-pub struct LeafStoreTxOutput {
-    // contains pages that can already be written in the LeafStore
-    pub to_allocate: Vec<(PageNumber, Box<Page>)>,
-    // contains pages that require the LeafStore to grow
-    pub exceeded: Vec<(PageNumber, Box<Page>)>,
-    pub new_free_list_head: PageNumber,
-}
-
-impl<'a> LeafStoreTx<'a> {
     pub fn allocate(&mut self, leaf_page: LeafNode) -> PageNumber {
         let leaf_pn = match self.free_list.pop() {
             Some(pn) => pn,
@@ -150,11 +128,8 @@ impl<'a> LeafStoreTx<'a> {
             }
         };
 
-        if leaf_pn.0 < self.max_bump.0 {
-            self.to_allocate.push((leaf_pn, leaf_page));
-        } else {
-            self.exceeded.push((leaf_pn, leaf_page));
-        }
+        self.pending.push((leaf_pn, leaf_page));
+
         leaf_pn
     }
 
@@ -162,41 +137,54 @@ impl<'a> LeafStoreTx<'a> {
         self.released.push(id);
     }
 
-    // commits the changes creating a set of pages that needs to be written into the LeafStore
-    pub fn commit(mut self) -> LeafStoreTxOutput {
-        let free_list_output = self
-            .free_list
-            .commit(self.released, &mut self.bump, self.max_bump);
+    // Commits the changes creating a set of pages that needs to be written into the LeafStore.
+    //
+    // The output will include not only the list of pages that need to be written but also
+    // the new free_list head, the current bump page number, and the new file size if extending is needed
+    pub fn commit(&mut self) -> LeafStoreCommitOutput {
+        let released = std::mem::take(&mut self.released);
+        let pending = std::mem::take(&mut self.pending);
 
-        let to_allocate = self
-            .to_allocate
+        let free_list_pages = self.free_list.commit(released, &mut self.bump);
+
+        let pages = pending
             .into_iter()
             .map(|(pn, leaf_page)| (pn, leaf_page.inner))
             .chain(
-                free_list_output
-                    .to_allocate
+                free_list_pages
                     .into_iter()
                     .map(|(pn, free_list_page)| (pn, free_list_page.inner)),
             )
             .collect::<Vec<_>>();
 
-        let exceeded = self
-            .exceeded
-            .into_iter()
-            .map(|(pn, leaf_page)| (pn, leaf_page.inner))
-            .chain(
-                free_list_output
-                    .exceeded
-                    .into_iter()
-                    .map(|(pn, free_list_page)| (pn, free_list_page.inner)),
-            )
-            .collect::<Vec<_>>();
+        // The LeafStore is expected to grow in increments of 1 MiB blocks,
+        // equivalent to chunks of 256 4KiB pages.
+        //
+        // If the self.bump exceeds the file_max_bump,
+        // the file will not be resized to store only the extra pages,
+        // but rather resized to store at least the new pages and possibly
+        // leaving some empty pages at the end.
+        let next_max_bump = self.bump.0.next_multiple_of(256);
+        let extend_file_sz = if self.file_max_bump.0 < next_max_bump {
+            self.file_max_bump = PageNumber(next_max_bump);
+            Some(self.file_max_bump.0 as usize * PAGE_SIZE)
+        } else {
+            None
+        };
 
-        LeafStoreTxOutput {
-            to_allocate,
-            exceeded,
+        LeafStoreCommitOutput {
+            pages,
+            bump: self.bump,
+            extend_file_sz,
             // after appending to the free list, the head will always be present
-            new_free_list_head: self.free_list.head_pn().unwrap(),
+            freelist_head_pn: self.free_list.head_pn().unwrap(),
         }
     }
+}
+
+pub struct LeafStoreCommitOutput {
+    pub pages: Vec<(PageNumber, Box<Page>)>,
+    pub bump: PageNumber,
+    pub extend_file_sz: Option<usize>,
+    pub freelist_head_pn: PageNumber,
 }

--- a/src/beatree/ops/mod.rs
+++ b/src/beatree/ops/mod.rs
@@ -40,7 +40,7 @@ pub fn lookup(
     todo!();
 }
 
-/// Change the btree in the specified way. Updates the branch index in-place and returns 
+/// Change the btree in the specified way. Updates the branch index in-place and returns
 /// a list of branches which have become obsolete.
 ///
 /// The changeset is a list of key value pairs to be added or removed from the btree.
@@ -50,9 +50,16 @@ pub fn update(
     changeset: BTreeMap<Key, Option<Vec<u8>>>,
     bbn_index: &mut Index,
     bnp: &mut branch::BranchNodePool,
-    leaf_store: &mut leaf::store::LeafStoreTx,
+    leaf_store: &mut leaf::store::LeafStoreWriter,
 ) -> Result<Vec<BranchId>> {
-    let _ = (sync_seqn, next_bbn_seqn, changeset, bbn_index, bnp, leaf_store);
+    let _ = (
+        sync_seqn,
+        next_bbn_seqn,
+        changeset,
+        bbn_index,
+        bnp,
+        leaf_store,
+    );
     todo!();
 }
 
@@ -81,7 +88,7 @@ fn search_branch(branch: &branch::BranchNode, key: Key) -> Option<leaf::PageNumb
 
     // sanity: this only happens if `key` is less than separator 0.
     if high == 0 {
-        return None
+        return None;
     }
     let node_pointer = branch.node_pointer(high - 1);
     Some(node_pointer.into())


### PR DESCRIPTION
LeafStoreTx would be useful solely to prevent the btree update logic from being able to call commit, which should only be callable from the writeout process.

To simplify and shorten things, however, I suggest sticking with only a LeafStoreWriter for now.

Another thing this pr introduce is a call to `fsync` in writeout