### PR TITLE
mmap in reconstruction

### DIFF
--- a/src/beatree/ops/reconstruction.rs
+++ b/src/beatree/ops/reconstruction.rs
@@ -7,24 +7,20 @@
 //!     Create a sorted list of this next layer of BNs as we go.
 //!   3. Repeat step 2 until the root node is created.
 
-use anyhow::{bail, ensure, Result};
+use anyhow::{bail, ensure, Ok, Result};
 use bitvec::prelude::*;
-use crossbeam_channel::Receiver;
 use std::{
     collections::BTreeSet,
     fs::File,
-    io::{ErrorKind, Read, Seek},
+    os::fd::AsRawFd,
+    ptr,
 };
 
 use crate::beatree::{
     allocator::PageNumber,
-    branch::{self, BRANCH_NODE_SIZE},
+    branch::{self, BranchNodeView, BRANCH_NODE_SIZE},
     index::Index,
 };
-
-// 256K
-const SEQ_READ_CHUNK_LEN: usize = BRANCH_NODE_SIZE * 64;
-type SeqReadChunk = [u8; SEQ_READ_CHUNK_LEN];
 
 /// Reconstruct the upper branch nodes of the btree from the bottom branch nodes and the leaf nodes.
 /// This places all branches into the BNP and returns an index into all BBNs.
@@ -36,72 +32,117 @@ pub fn reconstruct(
 ) -> Result<Index> {
     let mut index = Index::default();
 
-    let mut pn = 0u32;
-    for seq_chunk in read_sequential(bn_fd)? {
-        let seq_chunk = seq_chunk?;
-        let nodes = seq_chunk.chunks(BRANCH_NODE_SIZE);
-        for node in nodes {
-            if pn >= bump.0 {
-                // Exceeded last possible valid page
-                return Ok(index);
-            }
+    let mut chunker = SeqFileReader::new(bn_fd, bump.0)?;
+    while let Some((pn, node)) = chunker.next()? {
+        let view = BranchNodeView::from_slice(node);
+        ensure!(view.bbn_pn() == pn, "pn mismatch");
 
-            let view = branch::BranchNodeView::from_slice(node);
-            ensure!(view.bbn_pn() == pn, "pn mismatch");
-            if bbn_freelist.contains(&view.bbn_pn().into()) {
-                continue;
-            }
+        if view.n() == 0 && node == [0; BRANCH_NODE_SIZE] {
+            // Just skip empty nodes.
+            continue;
+        }
 
-            if view.n() == 0 && node == [0; BRANCH_NODE_SIZE] {
-                bail!("zero-length branch node")
-            }
+        if bbn_freelist.contains(&view.bbn_pn().into()) {
+            continue;
+        }
 
-            let new_branch_id = bnp.allocate();
+        let new_branch_id = bnp.allocate();
 
-            // UNWRAP: just allocated
-            bnp.checkout(new_branch_id)
-                .unwrap()
-                .as_mut_slice()
-                .copy_from_slice(node);
+        // UNWRAP: just allocated
+        bnp.checkout(new_branch_id)
+            .unwrap()
+            .as_mut_slice()
+            .copy_from_slice(node);
 
-            let mut separator = [0u8; 32];
-            {
-                let prefix = view.prefix();
-                let separator = separator.view_bits_mut::<Lsb0>();
-                separator[..prefix.len()].copy_from_bitslice(prefix);
-                let first = view.separator(0);
-                separator[prefix.len()..prefix.len() + first.len()].copy_from_bitslice(first);
-            }
+        let mut separator = [0u8; 32];
+        {
+            let prefix = view.prefix();
+            let separator = separator.view_bits_mut::<Lsb0>();
+            separator[..prefix.len()].copy_from_bitslice(prefix);
+            let first = view.separator(0);
+            separator[prefix.len()..prefix.len() + first.len()].copy_from_bitslice(first);
+        }
 
-            if let Some(_) = index.insert(separator, new_branch_id) {
-                bail!("2 branch nodes with same separator")
-            }
-
-            pn += 1;
+        if let Some(_) = index.insert(separator, new_branch_id) {
+            bail!("2 branch nodes with same separator")
         }
     }
-
     Ok(index)
 }
 
-fn read_sequential(mut bn_fd: File) -> Result<Receiver<Result<Box<SeqReadChunk>>>> {
-    let (tx, rx) = crossbeam_channel::unbounded();
-    bn_fd.seek(std::io::SeekFrom::Start(BRANCH_NODE_SIZE as u64))?;
-    std::thread::spawn(move || loop {
-        let mut buf = Box::new([0; SEQ_READ_CHUNK_LEN]);
-        match bn_fd.read_exact(&mut *buf) {
-            Ok(()) => {
-                let _ = tx.send(Ok(buf));
+/// An utility to read sequentially from a file.
+/// 
+/// This is backed by an mmap of the file. The kernel is instructed that the contents of the file
+/// should be read sequentially. This will make the kernel to read ahead the file sequentially.
+struct SeqFileReader {
+    ptr: *mut u8,
+    len: u64,
+    pn: u32,
+    bump: u32,
+}
+
+impl SeqFileReader {
+    fn new(bbn_fd: File, bump: u32) -> Result<Self> {
+        let len = bbn_fd.metadata()?.len();
+        ensure!(
+            len % BRANCH_NODE_SIZE as u64 == 0,
+            "file size is not a multiple of 4KiB page"
+        );
+        ensure!(
+            len >= BRANCH_NODE_SIZE as u64,
+            "file is too small for BBN store"
+        );
+
+        let pn = 0u32;
+        let ptr = unsafe {
+            // MAP_PRIVATE
+            //
+            //     PRIVATE vs. SHARED should not matter much since we are only reading. However, opt
+            //     for a private mapping because it would create a private mapping undisturbed from
+            //     the rest of the system. Not that this matters much since we take the assumption that
+            //     the file is under exclusive access of this process.
+            let flags = libc::MAP_PRIVATE;
+            let addr = libc::mmap(
+                ptr::null_mut(),
+                len as usize,
+                libc::PROT_READ,
+                flags,
+                bbn_fd.as_raw_fd(),
+                0,
+            );
+            if addr == libc::MAP_FAILED {
+                bail!("mmap failed");
             }
-            Err(e) if e.kind() == ErrorKind::UnexpectedEof => {
-                let _ = tx.send(Ok(buf));
-                break;
+            if libc::madvise(addr, len as usize, libc::MADV_SEQUENTIAL) != 0 {
+                bail!("madvise failed"); // although this should not be fatal
             }
-            Err(e) => {
-                let _ = tx.send(Err(anyhow::Error::from(e)));
-                break;
-            }
+            addr as *mut u8
+        };
+
+        Ok(Self { ptr, len, pn, bump })
+    }
+
+    pub fn next<'a>(&'a mut self) -> Result<Option<(u32, &'a [u8])>> {
+        if self.pn >= self.bump {
+            return Ok(None);
         }
-    });
-    Ok(rx)
+
+        let node = unsafe {
+            let offset = self.pn as usize * BRANCH_NODE_SIZE;
+            let ptr = self.ptr.offset(offset as isize);
+            std::slice::from_raw_parts(ptr, BRANCH_NODE_SIZE)
+        };
+
+        let pn = self.pn;
+        self.pn += 1;
+        Ok(Some((pn, node)))
+    }
+}
+
+impl Drop for SeqFileReader {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = libc::munmap(self.ptr as *mut _, self.len as usize);
+        }
+    }
 }


### PR DESCRIPTION
it's incorrect to bail upon encountering an empty node. This is because
read_sequential operated in bigger chunks than a page to make reading
more efficient. However, that also means that at some point not the
whole seq read chunk would be read and `read_exact` would report
unexpected EOF error, which is funny enough is expected.

However, the documentation states that after read_exact returns
unexpected EOF the contents of the output buffer are unspecified.

I first tried to re-implement using the original approach and fix
correctness, however, the implementation turned a bit too nasty and I
realized that I can simplify by leveraging mmap + read ahead.

Here is the documentation for MADV_SEQUENTIAL

	Expect page references in sequential order.  (Hence, pages
	in the given range can be aggressively read ahead, and may
	be freed soon after they are accessed.)

Therefore theoretically this should be even more efficient than the
previous implementation.

It also seems to be more simple, but I admit that it might be because
I dealt with this particular pattern a lot of times. It could be further
simplified by sweeping the unsafes under the rug by using one of
off-the-shelf libraries providing the same functionality.