### PR TITLE
fix allocator

### DIFF
--- a/src/beatree/allocator/mod.rs
+++ b/src/beatree/allocator/mod.rs
@@ -43,9 +43,11 @@ pub struct AllocatorReader {
 /// to storage to reflect the store's state at that moment
 pub struct AllocatorWriter {
     store_file: File,
-    io_handle_index: usize,
-    io_sender: Sender<IoCommand>,
-    io_receiver: Receiver<CompleteIo>,
+    // Currently unused, they may become useful when writes will be shared
+    // between this struct and the writeout method
+    _io_handle_index: usize,
+    _io_sender: Sender<IoCommand>,
+    _io_receiver: Receiver<CompleteIo>,
     // Monotonic page number, used when the free list is empty
     bump: PageNumber,
     // The store is an array of pages, with indices as PageNumbers,


### PR DESCRIPTION
The allocator had three major problems that require fixes:
1. Once decoded from the file, the portions of the free list were not reversed
2. If a new free page is either extracted from the free list or added, the header will need to be overwritten
3. If neither of the previous things happened, then nothing should be done
