### PR TITLE
add leaf store reader to sync

### DIFF
--- a/src/beatree/bbn.rs
+++ b/src/beatree/bbn.rs
@@ -31,19 +31,25 @@ pub fn create(
     rd_io_sender: Sender<IoCommand>,
     rd_io_receiver: Receiver<CompleteIo>,
 ) -> (BbnStoreWriter, BTreeSet<PageNumber>) {
-    let (allocator_reader, allocator_writer) = allocator::create(
-        fd,
+    let allocator_reader = AllocatorReader::new(
+        fd.try_clone().expect("failed to clone file"),
         free_list_head,
         bump,
-        wr_io_handle_index,
-        wr_io_sender,
-        wr_io_receiver,
         rd_io_handle_index,
         rd_io_sender,
         rd_io_receiver,
     );
 
     let freelist = allocator_reader.free_list().into_set();
+
+    let allocator_writer = AllocatorWriter::new(
+        fd,
+        free_list_head,
+        bump,
+        wr_io_handle_index,
+        wr_io_sender,
+        wr_io_receiver,
+    );
 
     (
         BbnStoreWriter {


### PR DESCRIPTION
leaf store reader must be owned by both shared and sync to make
it possible to retrieve leaves during updates and lookups,
one should not block the other