### PR TITLE
remove derive(Clone) from FreeList

### DIFF
--- a/src/beatree/allocator/free_list.rs
+++ b/src/beatree/allocator/free_list.rs
@@ -14,7 +14,6 @@ const MAX_PNS_PER_FREE_PAGE: usize = (PAGE_SIZE - 6) / 4;
 ///
 /// Pages that are freed due to the fetch of free pages are automatically added back during the encode phase,
 /// which also covers the addition of new free pages.
-#[derive(Clone)]
 pub struct FreeList {
     head: Option<(PageNumber, Vec<PageNumber>)>,
     portions: Vec<(PageNumber, Vec<PageNumber>)>,
@@ -84,14 +83,15 @@ impl FreeList {
         }
     }
 
-    pub fn into_set(self) -> BTreeSet<PageNumber> {
-        let Some(pns) = self.head.map(|(_, pns)| pns) else {
+    /// Copies all the elements present in the free list into a set
+    pub fn get_set(&self) -> BTreeSet<PageNumber> {
+        let Some(pns) = self.head.as_ref().map(|(_, pns)| pns.clone()) else {
             return BTreeSet::new();
         };
 
         let pns = vec![pns]
             .into_iter()
-            .chain(self.portions.into_iter().map(|(_, pns)| pns))
+            .chain(self.portions.iter().map(|(_, pns)| pns.clone()))
             .into_iter()
             .flatten()
             .into_iter();

--- a/src/beatree/bbn.rs
+++ b/src/beatree/bbn.rs
@@ -36,7 +36,7 @@ pub fn create(
         io_sender,
         io_receiver,
     );
-    let freelist = allocator_writer.free_list().clone().into_set();
+    let freelist = allocator_writer.free_list().get_set();
 
     (
         BbnStoreWriter {


### PR DESCRIPTION
Implementing Clone for the FreeList is not needed.
Only when a set from the FreeList needs to be created,
each element inside the FreeList will be copied

Solves https://github.com/thrumdev/bitbox/pull/56#discussion_r1698398146
